### PR TITLE
Update dependency to H5P.Question

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,7 +26,7 @@
     {
       "machineName": "H5PEditor.Wizard",
       "majorVersion": 1,
-      "minorVersion": 1
+      "minorVersion": 2
     },
     {
       "machineName": "H5PEditor.ImageMultipleHotspotQuestion",

--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
   "contentType": "Question",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 0,
+  "patchVersion": 1,
   "runnable": 1,
   "author": "Luke Muller",
   "coreApi": {
@@ -38,7 +38,7 @@
     {
       "machineName": "H5P.Question",
       "majorVersion": 1,
-      "minorVersion": 2
+      "minorVersion": 4
     }
   ]
 }


### PR DESCRIPTION
This content type seems to be the last one using version 1.2 of H5P.Question, thus blocking the old library version from being removed.

This pull request will update the dependency to H5P.Question and bump the patch version of this content type, so changes can be registered by H5P.